### PR TITLE
Bildunterschriften results

### DIFF
--- a/src/pages/Results.pug
+++ b/src/pages/Results.pug
@@ -25,7 +25,7 @@ block article
         Furthermore, the reaction was performed at room temperature (RT = 24 °C) and 37 °C to compare possible variations in maximal tail length and tail length distribution.
         
     - var imgpath = "" + require("../assets/img/Results/2021-06-23_01.png")["default"]
-    +image(1, imgpath, "TdT tailing reaction of an AT-rich ssDNA primer with the four standard dNTPs at RT and 37 °C for 30 min, containing $Co^{2+}$ as a cofactor. 2.5% Agarose with TBE, SYBR Gold staining, 90 V, 55 min. M: GeneRuler 50 bp DNA Ladder 1: AT-rich primer reference 2: RT reaction with dATP 3: RT reaction with dTTP 4: RT reaction with dCTP 5: RT reaction with dGTP 6: AT-rich primer reference 20 nM 7: 37 °C reaction with dATP 8: 37 °C with dTTP 9: 37 °C reaction with dCTP 10: 37 °C reaction with dGTP.")
+    +image(1, imgpath, "TdT tailing reaction of an AT-rich ssDNA primer with the four standard dNTPs at RT and 37 °C for 30 min, containing $Co^{2+}$ as a cofactor. 2.5% Agarose with TBE, SYBR Gold staining, 90 V, 55 min. M: GeneRuler 50 bp DNA Ladder 1: AT-rich primer reference 2: RT reaction with dATP 3: RT reaction with dTTP 4: RT reaction with dCTP 5: RT reaction with dGTP 6: AT-rich primer reference 20 nM 7: 37 °C reaction with dATP 8: 37 °C with dTTP 9: 37 °C reaction with dCTP 10: 37 °C reaction with dGTP.",100,0.8)
         
     :markdown-it
         Figure 1 reveals more effective incorporation of dTTP for both RT and 37 °C. 
@@ -43,7 +43,7 @@ block article
         The first parameter tested was the concentration of dNTP in the reaction mixture to identify potential effects on the reaction speed.
                 
     - var imgpath = "" + require("../assets/img/Results/2021-07-15_01.png")["default"]
-    +image(2, imgpath, "TdT tailing reaction of an AT-rich ssDNA primer with a range of initial dATP concentrations ranging from 1-1000 µM at RT (24 °C) for 10 min. 2.5% Agarose with TBE, SYBR Gold staining, 90 V, 55 min. M: GeneRuler 50 bp DNA Ladder 1: AT-rich primer reference 2: 1000 µM dATP 3: 500 µM dATP 4: 200 µM dATP 5: 100 µM dATP 6: 50 µM dATP 7: 20 µM dATP 8: 10 µM dATP 9: 1 µM dATP.")
+    +image(2, imgpath, "TdT tailing reaction of an AT-rich ssDNA primer with a range of initial dATP concentrations ranging from 1-1000 µM at RT (24 °C) for 10 min. 2.5% Agarose with TBE, SYBR Gold staining, 90 V, 55 min. M: GeneRuler 50 bp DNA Ladder 1: AT-rich primer reference 2: 1000 µM dATP 3: 500 µM dATP 4: 200 µM dATP 5: 100 µM dATP 6: 50 µM dATP 7: 20 µM dATP 8: 10 µM dATP 9: 1 µM dATP.",100,0.8)
         
     :markdown-it
         The gel shows a distortion in the form of a slight curve. However, all samples can be distinguished from the primer reference in lane 1.
@@ -60,7 +60,7 @@ block article
         Thus, different primer concentrations were tested with dTTP as past experiments showed more easily distinguishable bands than the other dNTPs.
         
     - var imgpath = "" + require("../assets/img/Results/2021-10-15_02.png")["default"]
-    +image(3, imgpath, "Figure 3 TdT tailing reaction of an AT-rich ssDNA primer with dTTP and various primer concentrations at RT (23 °C) for 60 min. 1.5% Agarose, SYBR Gold staining, 90 V, 60 min. M: GeneRuler 1 kb DNA Ladder 1: AT-rich primer reference 2: 100 nM  primer 2: 50 nM primer 3: 20 nM primer 4: 15 nM primer 5: 10 nM primer 6: 10 nM primer 7: 5 nM primer 8: 1 nM primer.")
+    +image(3, imgpath, "Figure 3 TdT tailing reaction of an AT-rich ssDNA primer with dTTP and various primer concentrations at RT (23 °C) for 60 min. 1.5% Agarose, SYBR Gold staining, 90 V, 60 min. M: GeneRuler 1 kb DNA Ladder 1: AT-rich primer reference 2: 100 nM  primer 2: 50 nM primer 3: 20 nM primer 4: 15 nM primer 5: 10 nM primer 6: 10 nM primer 7: 5 nM primer 8: 1 nM primer.",100,0.8)
         
     :markdown-it
         The reaction time was increased to 60 min to yield longer strands, making the lowest primer concentrations visible on a gel.
@@ -77,7 +77,7 @@ block article
         As the cofactor was inherently present in the buffer, we had to adjust the buffer concentration in total and could not just alter the cofactor concentration itself, which might have unforeseen effects.
         
     - var imgpath = "" + require("../assets/img/Results/2021-06-24_01.png")["default"]
-    +image(4, imgpath, "Figure 4 TdT tailing reaction of an AT-rich ssDNA primer with dTTP and various cofactor concentrations at RT (24 °C) for 30 min. Cofactor was inherently present in reaction buffer, so that buffer concentration was consequently adjusted as well. 2.5% Agarose with TBE, SYBR Gold staining, 90 V, 60 min. M: GeneRuler 50 bp DNA Ladder 1: AT.rich primer reference 2: 2 mM CoCl2 3: 1.5 mM CoCl2 4: 1.0 mM CoCl2 5: 0.5 mM CoCl2 6: 0.0 mM CoCl2 negative control.")
+    +image(4, imgpath, "Figure 4 TdT tailing reaction of an AT-rich ssDNA primer with dTTP and various cofactor concentrations at RT (24 °C) for 30 min. Cofactor was inherently present in reaction buffer, so that buffer concentration was consequently adjusted as well. 2.5% Agarose with TBE, SYBR Gold staining, 90 V, 60 min. M: GeneRuler 50 bp DNA Ladder 1: AT.rich primer reference 2: 2 mM CoCl2 3: 1.5 mM CoCl2 4: 1.0 mM CoCl2 5: 0.5 mM CoCl2 6: 0.0 mM CoCl2 negative control.",100,0.8)
         
     :markdown-it
         Reducing the cofactor presence results in slower incorporation of nucleotides in the tested range.
@@ -94,7 +94,7 @@ block article
         Additionally, the reaction time is an adjustable parameter that does not slow down the reaction but restricts the number of dNTPs added according to time. 
         
     - var imgpath = "" + require("../assets/img/Results/2021-06-23_02.png")["default"]
-    +image(5, imgpath, "Figure 5 TdT tailing reaction of an AT-rich ssDNA primer with dTTP and various reaction times ranging from 1-90 min at RT (24 °C). 2.5% Agarose with TBE, SYBR Gold staining, 90 V, 51 min,. M: GeneRuler 50 bp DNA Ladder 1: AT-rich primer reference 2: 1 min incubation 3: 5 min incubation 4: 15 min incubation 5: 30 min incubation 6: 60 min incubation 7: 90 min incubation.", 80)
+    +image(5, imgpath, "Figure 5 TdT tailing reaction of an AT-rich ssDNA primer with dTTP and various reaction times ranging from 1-90 min at RT (24 °C). 2.5% Agarose with TBE, SYBR Gold staining, 90 V, 51 min,. M: GeneRuler 50 bp DNA Ladder 1: AT-rich primer reference 2: 1 min incubation 3: 5 min incubation 4: 15 min incubation 5: 30 min incubation 6: 60 min incubation 7: 90 min incubation.",80,0.8)
         
     :markdown-it
         The depicted slope was obtained by preparing a 400 µL batch of the reaction, followed by initiation of the reaction through the addition of TdT, and subsequent withdrawal of 10 µL samples at the pre-set time points. 
@@ -109,7 +109,7 @@ block article
         The samples were analyzed externally by the Fraunhofer Institut IME Aachen.
         
     - var imgpath = "" + require("../assets/img/Results/CE_time_reaction_labelled.png")["default"]
-    +image(6, imgpath, "Figure 6 TdT tailing reaction of an AT-rich ssDNA primer  for each nucleotide in a time-dependent manner with reaction times ranging from 7.5-120 s at RT (24 °C). Time  standard LIZ600. (A) Resulting strand lengths for nucleotide T (B) Resulting strand lengths for nucleotide A (C) Resulting strand lengths for nucleotide C (D) Resulting strand lengths for nucleotide G. Non-elongated primer can be observed as a small bump at around 90 bp (actual primer length: 100 bp). Sample taking as a source of error is not included in this graph.")
+    +image(6, imgpath, "Figure 6 TdT tailing reaction of an AT-rich ssDNA primer  for each nucleotide in a time-dependent manner with reaction times ranging from 7.5-120 s at RT (24 °C). Time  standard LIZ600. (A) Resulting strand lengths for nucleotide T (B) Resulting strand lengths for nucleotide A (C) Resulting strand lengths for nucleotide C (D) Resulting strand lengths for nucleotide G. Non-elongated primer can be observed as a small bump at around 90 bp (actual primer length: 100 bp). Sample taking as a source of error is not included in this graph.",100,0.8)
         
     :markdown-it
         The CE reveals that the size distribution is smallest at very short reaction times of 7.5 to 20 seconds, except for nucleotide G.
@@ -123,7 +123,7 @@ block article
         For comparison, the samples at time point 120 s were additionally analyzed with gel electrophoresis. 
         
     - var imgpath = "" + require("../assets/img/Results/2021-07-08_01.png")["default"]
-    +image(7, imgpath, "Figure 7 TdT tailing reaction of an AT-rich ssDNA primer for each nucleotide in a time-dependent manner as in figure 5. 2.5% Agarose with TBE, SYBR Gold staining, 90 V, 60 min. M: Ultra Low Range DNA Ladder 1: AT-rich primer reference 2: dATP 120 s 3: dTTP 120 s 4: dCTP 120 s, 5: dGTP 120 s.")
+    +image(7, imgpath, "Figure 7 TdT tailing reaction of an AT-rich ssDNA primer for each nucleotide in a time-dependent manner as in figure 5. 2.5% Agarose with TBE, SYBR Gold staining, 90 V, 60 min. M: Ultra Low Range DNA Ladder 1: AT-rich primer reference 2: dATP 120 s 3: dTTP 120 s 4: dCTP 120 s, 5: dGTP 120 s.",100,0.8)
         
     :markdown-it
         The gel image reflects the behavior seen in figure 5 at 120 s.
@@ -150,7 +150,7 @@ block article
         We measured the absorbance at its maximum of 450 nm (table X).
         
     - var imgpath = "" + require("../assets/img/Results/2021-07-01_01.png")["default"]
-    +image(8, imgpath, "Samples after incubation with polystyrene stick and protein constructs. Immunoassay with the Penta-His-HRP-Antibodies and TMB as substrate. The yellow color quantifies the presence of antibodies and, therefore the presence of the anchor peptide. 1: His-eGFP (negative control), 2: His-C-DZ-LCI, 3: contains His-C-DZ-MacHis.", 80)
+    +image(8, imgpath, "Samples after incubation with polystyrene stick and protein constructs. Immunoassay with the Penta-His-HRP-Antibodies and TMB as substrate. The yellow color quantifies the presence of antibodies and, therefore the presence of the anchor peptide. 1: His-eGFP (negative control), 2: His-C-DZ-LCI, 3: contains His-C-DZ-MacHis.",80,0.8)
     
     - var imgpath = "" + require("../assets/img/Results/2021-07-01_table.png")["default"]
     +image(9, imgpath, "Absorbance at 450 nm of the protein samples after immunoassay. The negative control was 25 times more concentrated, so this factor has to be considered.")
@@ -168,7 +168,7 @@ block article
         To check whether the conjugation was successful, our instructor performed an SDS-PAGE to compare the protein before and after the reaction (figure X).
               
     - var imgpath = "" + require("../assets/img/Results/2021-07-22_SDS.png")["default"]
-    +image(10, imgpath, "Conjugation of AC6 AT-rich ssDNA Primer with the fusion protein. NuSep Tris-Glycine protein gel, Neo Biotech Quick Coomassie Stain overnight, 140 V, 70 min. The samples were heated to 95 °C for 10 min. M: PageRuler Prestained Protein Ladder 1: protein before conjugation (negative control), 2: protein after conjugation with AT-rich ssDNA primer.", 50)
+    +image(10, imgpath, "Conjugation of AC6 AT-rich ssDNA Primer with the fusion protein. NuSep Tris-Glycine protein gel, Neo Biotech Quick Coomassie Stain overnight, 140 V, 70 min. The samples were heated to 95 °C for 10 min. M: PageRuler Prestained Protein Ladder 1: protein before conjugation (negative control), 2: protein after conjugation with AT-rich ssDNA primer.", 50,0.8)
         
     :markdown-it
         It was expected that the conjugate runs significantly higher than the negative control because the primer is 100 nt long and increases the molecular weight, which should impact the running behavior. 
@@ -186,7 +186,7 @@ block article
         To analyze these reactions, we performed an agarose gel electrophoresis (figure X).  
         
     - var imgpath = "" + require("../assets/img/Results/2021-08-03_01.png")["default"]
-    +image(11, imgpath, "Standard TdT reaction (dTTP 15 min) with the conjugate and elutions of immobilizations with AC6 primer and AC6 primer-peptide conjugate. 2.5% Agarose with TBE, SYBR Gold, staining, 90 V, 60 min. M: GeneRuler 50 bp DNA Ladder 1: AC6 primer 2: AC6 primer after TdT reaction 3: AC6-primer-peptide conjugate 4: heated AC6-primer-peptide conjugate 5: AC6-primer-peptide conjugate after TdT reaction 6: elution of AC6-primer after immobilization 7: elution of AC6-primer after immobilization and TdT reaction 8: elution of AC6-primer-peptide conjugate after immobilization 9: elution of AC6-primer-peptide conjugate after immobilization and TdT reaction.")
+    +image(11, imgpath, "Standard TdT reaction (dTTP 15 min) with the conjugate and elutions of immobilizations with AC6 primer and AC6 primer-peptide conjugate. 2.5% Agarose with TBE, SYBR Gold, staining, 90 V, 60 min. M: GeneRuler 50 bp DNA Ladder 1: AC6 primer 2: AC6 primer after TdT reaction 3: AC6-primer-peptide conjugate 4: heated AC6-primer-peptide conjugate 5: AC6-primer-peptide conjugate after TdT reaction 6: elution of AC6-primer after immobilization 7: elution of AC6-primer after immobilization and TdT reaction 8: elution of AC6-primer-peptide conjugate after immobilization 9: elution of AC6-primer-peptide conjugate after immobilization and TdT reaction.",100,0.8)
         
     :markdown-it
         Lane 2 shows that the AC6-primer itself can be elongated by the TdT.
@@ -206,7 +206,7 @@ block article
         Assuming that successfully binding the protein construct to the oligo would change its running behavior, we performed an agarose gel electrophoresis with the conjugates.
     
     - var imgpath = "" + require("../assets/img/Results/2021-08-19_01.png")["default"]
-    +image(12, imgpath, "**Conjugations of LCI-fusion-protein with AT-rich and GC-rich maleimide-labeled ssDNA primers and different primer excesses.** 2.5% Agarose with TBE, 90 V, 60 min, SYBR Gold staining. M: GeneRuler 50 bp DNA Ladder 1: GC-rich primer reference 2: AT-rich primer reference, 3: Conjugation with 12.5x GC-rich primer excess 4: Conjugation with 5x GC-rich primer excess 5: Conjugation with 2x GC-rich primer excess 6: Conjugation with 12.5x AT-rich primer excess.")
+    +image(12, imgpath, "<b>Conjugations of LCI-fusion-protein with AT-rich and GC-rich maleimide-labeled ssDNA primers and different primer excesses.</b> 2.5% Agarose with TBE, 90 V, 60 min, SYBR Gold staining. M: GeneRuler 50 bp DNA Ladder 1: GC-rich primer reference 2: AT-rich primer reference, 3: Conjugation with 12.5x GC-rich primer excess 4: Conjugation with 5x GC-rich primer excess 5: Conjugation with 2x GC-rich primer excess 6: Conjugation with 12.5x AT-rich primer excess.",100,0.8)
     
     :markdown-it
         Figure # shows clear primer bands as reference. The GC-rich oligo runs lower than the AT-rich oligo because of secondary structure formation in the native gel. 
@@ -218,7 +218,7 @@ block article
         Unfortunately, the blot did not work and we did not have enough of the samples to try again.
         
     - var imgpath = "" + require("../assets/img/Results/2021-08-25_02.png")["default"]
-    +image(13, imgpath, "**Standard TdT reactions with dTTP with purified conjugations of LCI-fusion-protein and ssDNA primers.** 2.5% Agarose with TBE, 90 V, 60 min, SYBR Gold staining. M: GeneRuler 50 bp DNA Ladder 1: AT-rich primer reference 2: GC-rich primer reference, 3: Conjugation with 12.5x GC-rich primer excess 4: TdT reaction with 12.5x-GC-conjugate 5: Conjugation with 5x GC-rich primer excess 6: TdT reaction with 5x-GC-conjugate 7: Conjugation with 2x GC-rich primer excess 8: TdT reaction with 2x-GC-conjugate 9: Conjugation with 12.5x AT-rich primer excess 10: TdT reaction with 12.5x-AT-conjugate 11: Conjugation with PEG (positive control for protein gel) 12: TdT reaction with PEG-Conjugation (negative control).")
+    +image(13, imgpath, "<b>Standard TdT reactions with dTTP with purified conjugations of LCI-fusion-protein and ssDNA primers.</b> 2.5% Agarose with TBE, 90 V, 60 min, SYBR Gold staining. M: GeneRuler 50 bp DNA Ladder 1: AT-rich primer reference 2: GC-rich primer reference, 3: Conjugation with 12.5x GC-rich primer excess 4: TdT reaction with 12.5x-GC-conjugate 5: Conjugation with 5x GC-rich primer excess 6: TdT reaction with 5x-GC-conjugate 7: Conjugation with 2x GC-rich primer excess 8: TdT reaction with 2x-GC-conjugate 9: Conjugation with 12.5x AT-rich primer excess 10: TdT reaction with 12.5x-AT-conjugate 11: Conjugation with PEG (positive control for protein gel) 12: TdT reaction with PEG-Conjugation (negative control).",100,0.8)
         
     :markdown-it
         The gel electrophoresis reveals inconclusive results: The purified conjugates are not visible. The concentration is most likely too low to be detected. 
@@ -226,7 +226,7 @@ block article
         This gel was replicated and the conjugates were applied in a higher concentration.
         
     - var imgpath = "" + require("../assets/img/Results/2021-08-26_01.png")["default"]
-    +image(14, imgpath, "**Standard TdT reactions with dTTP with purified conjugates of LCI-fusion-protein and ssDNA primers.** 2.5% Agarose with TBE, 90 V, 49 min, SYBR Gold staining. M: GeneRuler 50 bp DNA Ladder 1: AT-rich primer reference 2: GC-rich primer reference, 3: Conjugation with 12.5x GC-rich primer excess 4: TdT reaction with 12.5x-GC-conjugate 5: Conjugation with 5x GC-rich primer excess 6: TdT reaction with 5x-GC-conjugate 7: Conjugation with 2x GC-rich primer excess 8: TdT reaction with 2x-GC-conjugate 9: Conjugation with 12.5x AT-rich primer excess 10: TdT reaction with 12.5x-AT-conjugate 11: Conjugation with PEG (positive control for protein gel) 12: TdT reaction with PEG-Conjugation (negative control).")
+    +image(14, imgpath, "<b>Standard TdT reactions with dTTP with purified conjugates of LCI-fusion-protein and ssDNA primers.</b> 2.5% Agarose with TBE, 90 V, 49 min, SYBR Gold staining. M: GeneRuler 50 bp DNA Ladder 1: AT-rich primer reference 2: GC-rich primer reference, 3: Conjugation with 12.5x GC-rich primer excess 4: TdT reaction with 12.5x-GC-conjugate 5: Conjugation with 5x GC-rich primer excess 6: TdT reaction with 5x-GC-conjugate 7: Conjugation with 2x GC-rich primer excess 8: TdT reaction with 2x-GC-conjugate 9: Conjugation with 12.5x AT-rich primer excess 10: TdT reaction with 12.5x-AT-conjugate 11: Conjugation with PEG (positive control for protein gel) 12: TdT reaction with PEG-Conjugation (negative control).",100,0.8)
         
     :markdown-it
         Here one can see that the conjugates produce a band approximately at the same height as the reference. 
@@ -248,7 +248,7 @@ block article
         Furthermore, a TdT reaction was performed in the immobilized state.
         
     - var imgpath = "" + require("../assets/img/Results/2021-08-27_01.png")["default"]
-    +image(15, imgpath, "**Immobilization of purified conjugates of LCI-fusion-protein and ssDNA primers on polystyrene stick. Washing steps with 1x PBS buffer, TdT reaction with dTTP, elution by heating to 95 °C.** 2.5% Agarose with TBE, 90 V, 49 min, SYBR Gold staining. M: GeneRuler 50 bp DNA Ladder 1: AT-rich maleimide primer (AT-M) reference 2: AT-M 1st wash solution 3: AT-M 2nd wash solution 4: AT-M elution 5: 12.5x GC-conjugate reference 6: 12.5x GC 1st wash solution 7: 12.5x GC 2nd wash solution 8: 12.5x GC elution 9: 12.5x GC 1st wash solution 10: 12.5x GC 2nd wash solution 11: 12.5x GC TdT reaction solution 12: 12.5x GC TdT elution 13: 5x GC-conjugate reference 14: 5x GC 1st wash solution 15: 5x GC 2nd wash solution 16: 5x GC elution 17: 5x GC 1st wash solution 18: 5x GC 2nd wash solution 19: 5x GC TdT reaction solution 20: 5x GC TdT elution 21: 2x GC-conjugate reference 22: 2x GC 1st wash solution 23: 2x GC 2nd wash solution 24: 2x GC elution 25: 2x GC 1st wash solution 26: 2x GC 2nd wash solution 27: 2x GC TdT reaction solution 28: 2x GC TdT elution 29: 12.5x AT-conjugate reference 30: 12.5x AT 1st wash solution 31: 12.5x AT 2nd wash solution 32: 12.5x AT elution 33: 12.5x AT 1st wash solution 34: 12.5x AT 2nd wash solution 35: 12.5x AT TdT reaction solution 36: 12.5x AT TdT elution.")
+    +image(15, imgpath, "<b>Immobilization of purified conjugates of LCI-fusion-protein and ssDNA primers on polystyrene stick. Washing steps with 1x PBS buffer, TdT reaction with dTTP, elution by heating to 95 °C.</b> 2.5% Agarose with TBE, 90 V, 49 min, SYBR Gold staining. M: GeneRuler 50 bp DNA Ladder 1: AT-rich maleimide primer (AT-M) reference 2: AT-M 1st wash solution 3: AT-M 2nd wash solution 4: AT-M elution 5: 12.5x GC-conjugate reference 6: 12.5x GC 1st wash solution 7: 12.5x GC 2nd wash solution 8: 12.5x GC elution 9: 12.5x GC 1st wash solution 10: 12.5x GC 2nd wash solution 11: 12.5x GC TdT reaction solution 12: 12.5x GC TdT elution 13: 5x GC-conjugate reference 14: 5x GC 1st wash solution 15: 5x GC 2nd wash solution 16: 5x GC elution 17: 5x GC 1st wash solution 18: 5x GC 2nd wash solution 19: 5x GC TdT reaction solution 20: 5x GC TdT elution 21: 2x GC-conjugate reference 22: 2x GC 1st wash solution 23: 2x GC 2nd wash solution 24: 2x GC elution 25: 2x GC 1st wash solution 26: 2x GC 2nd wash solution 27: 2x GC TdT reaction solution 28: 2x GC TdT elution 29: 12.5x AT-conjugate reference 30: 12.5x AT 1st wash solution 31: 12.5x AT 2nd wash solution 32: 12.5x AT elution 33: 12.5x AT 1st wash solution 34: 12.5x AT 2nd wash solution 35: 12.5x AT TdT reaction solution 36: 12.5x AT TdT elution.",100,0.8)
         
     :markdown-it
         Unfortunately, the concentrations are so low that it is hard to see bands. 
@@ -269,7 +269,7 @@ block article
         But the PCR samples are not relevant for this experiment.
         
     - var imgpath = "" + require("../assets/img/teamlogo_2021.svg")["default"]
-    +image(16, imgpath, "TdT reaction solution samples from immobilization experiment (figure x, lanes 11, 19, 27, 35) and PCR with those samples (not relevant). 2.5% Agarose with TBE, 90 V, 49 min, SYBR Gold staining. M: GeneRuler 50 bp DNA Ladder 1: AT-M primer reference 2: PCR with AT-M 3: 12.5x GC TdT reaction solution 4: PCR with 12.5x GC TdT reaction solution 5: 5x GC TdT reaction solution 6: PCR with 5x GC TdT reaction solution 7: 2x GC TdT reaction solution 8: PCR with 2x GC TdT reaction solution 9: 12.5x AT TdT reaction solution 10: PCR with 12.5x AT TdT reaction solution.")
+    +image(16, imgpath, "TdT reaction solution samples from immobilization experiment (figure x, lanes 11, 19, 27, 35) and PCR with those samples (not relevant). 2.5% Agarose with TBE, 90 V, 49 min, SYBR Gold staining. M: GeneRuler 50 bp DNA Ladder 1: AT-M primer reference 2: PCR with AT-M 3: 12.5x GC TdT reaction solution 4: PCR with 12.5x GC TdT reaction solution 5: 5x GC TdT reaction solution 6: PCR with 5x GC TdT reaction solution 7: 2x GC TdT reaction solution 8: PCR with 2x GC TdT reaction solution 9: 12.5x AT TdT reaction solution 10: PCR with 12.5x AT TdT reaction solution.",100,0.8)
         
     :markdown-it
         The reference bands are visible.
@@ -279,7 +279,7 @@ block article
         The samples were dissolved in agarose dissolving buffer, one part was purified and a dot blot (immunoblot) was performed to confirm or falsify the presence of protein.
         
     - var imgpath = "" + require("../assets/img/Results/2021-09-09_blot.png")["default"]
-    +image(17, imgpath, "Purified TdT reaction solution samples from gel (figure x). Trans-Blot Turbo membrane, Penta·His HRP Conjugate Kit (Qiagen), 1:2500 dilution in BSA, incubation for 1 h. A1: 12.5x GC TdT reaction solution lower band dissolved A2: 12.5x GC TdT reaction solution lower band purified B1: 12.5x GC TdT reaction solution upper band dissolved B2: 12.5x GC TdT reaction solution upper band purified C1: 12.5x AT TdT reaction solution lower band dissolved C2: 12.5x AT TdT reaction solution lower band purified D1: 12.5x AT TdT reaction solution upper band dissolved D2: 12.5x AT TdT reaction solution upper band purified E1: His-C-DZ-LCI (positive control) E2: empty.", 50)
+    +image(17, imgpath, "Purified TdT reaction solution samples from gel (figure x). Trans-Blot Turbo membrane, Penta·His HRP Conjugate Kit (Qiagen), 1:2500 dilution in BSA, incubation for 1 h. A1: 12.5x GC TdT reaction solution lower band dissolved A2: 12.5x GC TdT reaction solution lower band purified B1: 12.5x GC TdT reaction solution upper band dissolved B2: 12.5x GC TdT reaction solution upper band purified C1: 12.5x AT TdT reaction solution lower band dissolved C2: 12.5x AT TdT reaction solution lower band purified D1: 12.5x AT TdT reaction solution upper band dissolved D2: 12.5x AT TdT reaction solution upper band purified E1: His-C-DZ-LCI (positive control) E2: empty.", 50,0.8)
         
     :markdown-it
         The positive control is visible, but no other dots. 
@@ -302,7 +302,7 @@ block article
         A controlled elution of the primers was possible, indicated by a band at primer height.
         
     - var imgpath = "" + require("../assets/img/Results/2021-10-05.png")["default"]
-    +image(18, imgpath, "<b>Permanent immobilization using biotin-streptavidin binding.</b> A) Magnet beads and primer were conjugated first, and the magnet stick was added afterwards. B) Magnet beads were attached to the magnet stick and primer was added afterwards. 2.5% Agarose TBE, SYBR Gold, 90V, 45 min. M: GeneRuler 50 bp DNA Ladder 1: Biotin-labelled N-Primer 2: Conjugation rest 3: Wash rest 4: Wash rest 5: Elution.")        
+    +image(18, imgpath, "<b>Permanent immobilization using biotin-streptavidin binding.</b> A) Magnet beads and primer were conjugated first, and the magnet stick was added afterwards. B) Magnet beads were attached to the magnet stick and primer was added afterwards. 2.5% Agarose TBE, SYBR Gold, 90V, 45 min. M: GeneRuler 50 bp DNA Ladder 1: Biotin-labelled N-Primer 2: Conjugation rest 3: Wash rest 4: Wash rest 5: Elution.",100,0.8)        
         
     :markdown-it
         Another possibility to immobilize primers permanently, was to bind the streptavidin-tagged magnet beads to the magnet stick first and add biotin-labelled primer afterwards.
@@ -323,7 +323,7 @@ block article
         The magnetic binding was apparently not weakened by the envelope because there was no DNA detected in the immobilization rest. 
         
     - var imgpath = "" + require("../assets/img/teamlogo_2021.svg")["default"]
-    +image(19, imgpath, "**Non-permanent primer immobilization using biotin-streptavidin binding.** 2.5% Agarose TBE, SYBR Gold, 90 V, ? min. M: GeneRuler 50 bp DNA Ladder 1: Biotin-labelled N-Primer 2: Immobilization rest 3: Wash rest 4: Wash rest 5: Elution.")        
+    +image(19, imgpath, "<b>Non-permanent primer immobilization using biotin-streptavidin binding.</b> 2.5% Agarose TBE, SYBR Gold, 90 V, ? min. M: GeneRuler 50 bp DNA Ladder 1: Biotin-labelled N-Primer 2: Immobilization rest 3: Wash rest 4: Wash rest 5: Elution.",100,0.8)        
         
     :markdown-it
         As a result, the permanent immobilization was more efficient, if biotin-labelled primers are first conjugated to magnetic beads and the magnetic stick is added afterwards.

--- a/src/templates/mixins.pug
+++ b/src/templates/mixins.pug
@@ -39,7 +39,7 @@ mixin image(n, url, caption, width, fontSize)
             p= "Figure " + n + ": " + caption
         else if fontSize && width
             img(src=url alt=caption style="width: " + width + "%")
-            p(style="font-size:" + fontSize + "rem")!= "<b>Figure " + n + "</b>: " + caption
+            p(style="font-size:" + fontSize + "rem; text-align:justify" )!= "<b>Figure " + n + "</b>: " + caption
         else
             img(src=url alt=caption)
             p= "Figure " + n + ": " + caption

--- a/src/templates/mixins.pug
+++ b/src/templates/mixins.pug
@@ -32,13 +32,17 @@ mixin buttonRight(buttonTitle)
             span.icon.arrow
         span.button-text= buttonTitle
 
-mixin image(n, url, caption, width)
+mixin image(n, url, caption, width, fontSize)
     .image
-        if width
+        if width && !fontSize
             img(src=url alt=caption style="width: " + width + "%")
+            p= "Figure " + n + ": " + caption
+        else if fontSize && width
+            img(src=url alt=caption style="width: " + width + "%")
+            p(style="font-size:" + fontSize + "rem")!= "<b>Figure " + n + "</b>: " + caption
         else
             img(src=url alt=caption)
-        p= "Figure " + n + ": " + caption
+            p= "Figure " + n + ": " + caption
 
 mixin video(url, caption)
     video(style="width: 100%;" controls)


### PR DESCRIPTION
In Anlehnung an #251 
Habe alle Wünsche aus diesem Issue adressiert. Bitte einmal drüberschauen ob das so in Ordnung ist.
Ich habe hierfür das Image Mixin verändert. Das Pattern sieht jetzt so aus:
`+image(n, url, caption, width, fontSize)`
Hierbei ist width die Breite in Prozent (gab es aber schon vorher) und fontSize die Schriftgröße in `rem`
Wenn ihr eine Schriftgröße setzen wollt, dann müsst ihr auch die Breite setzen, könnt aber problemlos dann 100% angeben, da dies ohnehin der Standardfall ist.

Weiterhin, wenn ich einen Satz in der Caption dick haben wollt, dann benutzt statt der Doppelsternchen die HTML-Tags `<b>` und `</b>`

Also zum Beispiel "`Willy <b> IST SAUER </b>`"
